### PR TITLE
Add self.timeout on get/post/put and delete method of Client.session

### DIFF
--- a/src/vonage/client.py
+++ b/src/vonage/client.py
@@ -62,6 +62,10 @@ class Client:
         provided by this library and can be used to track your app statistics.
     :param str app_version: This optional value is added to the user-agent header
         provided by this library and can be used to track your app statistics.
+    :param timeout: (optional) How many seconds to wait for the server to send data
+        before giving up, as a float, or a (connect timeout, read
+        timeout) tuple. If set this timeout is used for every call to the Vonage enpoints
+    :type timeout: float or tuple
     """
 
     def __init__(
@@ -203,7 +207,7 @@ class Client:
         logger.debug(f"GET to {repr(uri)} with params {repr(params)}, headers {repr(self._request_headers)}")
         return self.parse(
             host, 
-            self.session.get(uri, params=params, headers=self._request_headers))
+            self.session.get(uri, params=params, headers=self._request_headers, timeout=self.timeout))
 
     def post(self, host, request_uri, params, auth_type=None, body_is_json=True, supports_signature_auth=False):
         """
@@ -239,10 +243,10 @@ class Client:
         logger.debug(f"POST to {repr(uri)} with params {repr(params)}, headers {repr(self._request_headers)}")
         if body_is_json:
             return self.parse(
-                host, self.session.post(uri, json=params, headers=self._request_headers))
+                host, self.session.post(uri, json=params, headers=self._request_headers, timeout=self.timeout))
         else:
             return self.parse(
-                host, self.session.post(uri, data=params, headers=self._request_headers))
+                host, self.session.post(uri, data=params, headers=self._request_headers, timeout=self.timeout))
 
     def put(self, host, request_uri, params, auth_type=None):
         uri = f"https://{host}{request_uri}"
@@ -262,7 +266,7 @@ class Client:
 
         logger.debug(f"PUT to {repr(uri)} with params {repr(params)}, headers {repr(self._request_headers)}")
         # All APIs that currently use put methods require a json-formatted body so don't need to check this
-        return self.parse(host, self.session.put(uri, json=params, headers=self._request_headers))
+        return self.parse(host, self.session.put(uri, json=params, headers=self._request_headers, timeout=self.timeout))
 
     def delete(self, host, request_uri, auth_type=None):
         uri = f"https://{host}{request_uri}"
@@ -282,7 +286,7 @@ class Client:
 
         logger.debug(f"DELETE to {repr(uri)} with headers {repr(self._request_headers)}")
         return self.parse(
-            host, self.session.delete(uri, headers=self._request_headers)
+            host, self.session.delete(uri, headers=self._request_headers, timeout=self.timeout)
         )
 
     def parse(self, host, response):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,3 +106,15 @@ def test_client_can_make_application_requests_without_api_key(dummy_data):
 def test_invalid_auth_type_raises_error(client):
     with pytest.raises(InvalidAuthenticationTypeError):
         client.get(client.host(), 'my/request/uri', auth_type='magic')
+
+@responses.activate
+def test_timeout_is_set_on_client_calls(dummy_data):
+    stub(responses.POST, "https://api.nexmo.com/v1/calls")
+
+    client = vonage.Client(application_id="myid", private_key=dummy_data.private_key, timeout=1)
+    voice = vonage.Voice(client)
+    voice.create_call("123455")
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.req_kwargs["timeout"] == 1
+


### PR DESCRIPTION
On Client a timeout parameter can be define in the `__init__` method This parameter is used to set `self.timeout` but is not used afterward.

This PR adds `self.timeout` each time `self.session` make a request

cf. https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts