### PR TITLE
Bugfix in messages.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,5 +6,3 @@ tag = False
 [bumpversion:file:src/vonage/__init__.py]
 
 [bumpversion:file:setup.py]
-
-[bumpversion:file:docs/conf.py]

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV*
 .idea
 .pypirc
 .pytest_cache
+html/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 3.0.2
+- Bugfix in `messages.py` where authentication method was not being checked for correctly, throwing an error when using header auth.
+
 # 3.0.1
 - Fixed bug where a JWT was created globally and could expire. Now a new JWT is generated when a request is made.
 - Fixed bug where timeout was not passed to session object.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(
 
 setup(
     name="vonage",
-    version="3.0.1",
+    version="3.0.2",
     description="Vonage Server SDK for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/vonage/__init__.py
+++ b/src/vonage/__init__.py
@@ -1,3 +1,3 @@
 from .client import *
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/vonage/messages.py
+++ b/src/vonage/messages.py
@@ -16,10 +16,10 @@ class Messages:
         self._client = client
         self._auth_type = 'jwt'
 
-    def send_message(self, params: dict):        
+    def send_message(self, params: dict):       
         self.validate_send_message_input(params)
         
-        if self._client._application_id is None:
+        if not hasattr(self._client, '_application_id'):
             self._auth_type='header'
         return self._client.post(
             self._client.api_host(), 


### PR DESCRIPTION
Bugfix in `messages.py` where authentication method was not being checked for correctly, throwing an error when using header auth.