### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.2
+current_version = 3.1.0
 commit = True
 tag = False
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "macos-latest"]
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 3.1.0
+- Supporting Python 3.11
+- Upgrading some old dependencies
+
 # 3.0.2
 - Bugfix in `messages.py` where authentication method was not being checked for correctly, throwing an error when using header auth.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean test build coverage install requirements release
 
 coverage:
-	pytest -v --cov
+	coverage run -m pytest -v
 	coverage html
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 -e .
 pytest==7.2.0
-pytest-cov==3.0.0
-responses==0.20.0
-coveralls
-glom==22.1.0
+responses==0.22.0
+coverage
 
 bump2version
 build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-pytest==7.1.1
+pytest==7.2.0
 pytest-cov==3.0.0
 responses==0.20.0
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(
 
 setup(
     name="vonage",
-    version="3.0.2",
+    version="3.1.0",
     description="Vonage Server SDK for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/vonage/__init__.py
+++ b/src/vonage/__init__.py
@@ -1,3 +1,3 @@
 from .client import *
 
-__version__ = "3.0.2"
+__version__ = "3.1.0"

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,7 +1,5 @@
 import platform
 
-from glom import glom
-
 from util import *
 
 import vonage
@@ -118,10 +116,7 @@ def test_list_secrets(account):
 
     secrets = account.list_secrets("myaccountid")
     assert_basic_auth()
-    assert (
-        glom(secrets, "_embedded.secrets.0.id")
-        == "ad6dc56f-07b5-46e1-a527-85530e625800"
-    )
+    assert secrets["_embedded"]["secrets"][0]["id"] == "ad6dc56f-07b5-46e1-a527-85530e625800"
 
 
 @responses.activate


### PR DESCRIPTION
I've added 3.11 to the github action that runs the tests, as well as removed some unnecessary dependencies.