### PR TITLE
Catching exceptions where the API returns with HTTP status 200

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
 
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Clone repo

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,0 +1,36 @@
+name: Mutation Test
+on: workflow_dispatch
+
+jobs:
+  mutation:
+    name: run mutation test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10"]
+
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install mutmut
+    - name: Run mutation test
+      run: |
+        mutmut run --no-progress || \
+        if [ $? -eq 1 ]; then exit 1; fi
+    - name: Save HTML output
+      run: |
+        mutmut html
+    - uses: actions/upload-artifact@v3
+      with:
+        name: mutation-test-report
+        path: html/

--- a/src/vonage/errors.py
+++ b/src/vonage/errors.py
@@ -58,8 +58,12 @@ class TokenExpiryError(Error):
 
 class InvalidOptionsError(Error):
     """The option(s) that were specified are invalid."""
-    """An authentication method was specified that is not allowed"""
+    """An authentication method was specified that is not allowed."""
 
 
 class VerifyError(Error):
-    """Error related to the Verify API"""
+    """Error related to the Verify API."""
+
+
+class BlockedNumberError(Error):
+    """The number you are trying to verify is blocked for verification."""

--- a/src/vonage/errors.py
+++ b/src/vonage/errors.py
@@ -67,3 +67,7 @@ class VerifyError(Error):
 
 class BlockedNumberError(Error):
     """The number you are trying to verify is blocked for verification."""
+
+
+class NumberInsightError(Error):
+    """Error related to the Number Insight API."""

--- a/src/vonage/errors.py
+++ b/src/vonage/errors.py
@@ -27,8 +27,22 @@ class MessagesError(Error):
 class PricingTypeError(Error):
     """A pricing type was specified that is not allowed."""
 
+
 class RedactError(Error):
     """Error related to the Redact class or Redact API."""
 
+
 class InvalidAuthenticationTypeError(Error):
-    """An authentication method was specified that is not allowed"""
+    """An authentication method was specified that is not allowed."""
+
+
+class InvalidRoleError(Error):
+    """The specified role was invalid."""
+
+
+class TokenExpiryError(Error):
+    """The specified token expiry time was invalid."""
+
+
+class InvalidOptionsError(Error):
+    """The option(s) that were specified are invalid."""

--- a/src/vonage/errors.py
+++ b/src/vonage/errors.py
@@ -24,6 +24,12 @@ class MessagesError(Error):
     """
 
 
+class SmsError(Error):
+    """
+    Indicates an error related to the Sms class which calls the Vonage SMS API.
+    """
+
+
 class PricingTypeError(Error):
     """A pricing type was specified that is not allowed."""
 

--- a/src/vonage/number_insight.py
+++ b/src/vonage/number_insight.py
@@ -29,21 +29,30 @@ class NumberInsight:
         argoparams = params or kwargs
         self.check_for_callback(argoparams)
         
-        if "callback" in argoparams and type(argoparams["callback"]) == str and argoparams["callback"] != "":
-            return self._client.get(
-                self._client.api_host(), "/ni/advanced/async/json", params or kwargs, auth_type=NumberInsight.auth_type
-            )
-        else:
-            raise CallbackRequiredError(
-                "A callback is needed for async advanced number insight"
-            )
+        response = self._client.get(
+            self._client.api_host(), "/ni/advanced/async/json", params or kwargs, auth_type=NumberInsight.auth_type
+        )
+        print(json.dumps(response, indent=4))
+        self.check_for_async_error(response)
+
+        return response
     
     def check_for_error(self, response):
         if response['status'] != 0:
-            raise NumberInsightError(f'Number Insight API method failed with status: {response["status"]} and error: {response["status_message"]}')
+            raise NumberInsightError(
+                f'Number Insight API method failed with status: {response["status"]} and error: {response["status_message"]}'
+            )
+
+    def check_for_async_error(self, response):
+        if response['status'] != 0:
+            raise NumberInsightError(
+                f'Number Insight API method failed with status: {response["status"]} and error: {response["error_text"]}'
+            )
 
     def check_for_callback(self, argoparams):
-        if not any("callback" in argoparams and type(argoparams["callback"]) == str and argoparams["callback"] != ""):
+        if "callback" in argoparams and type(argoparams["callback"]) == str and argoparams["callback"] != "":
+            pass
+        else:
             raise CallbackRequiredError(
                 "A callback is needed for async advanced number insight"
             )

--- a/src/vonage/number_insight.py
+++ b/src/vonage/number_insight.py
@@ -1,4 +1,5 @@
-from .errors import CallbackRequiredError
+from .errors import CallbackRequiredError, NumberInsightError
+import json
 
 class NumberInsight:
     auth_type = 'params'
@@ -7,16 +8,27 @@ class NumberInsight:
         self._client = client
 
     def get_basic_number_insight(self, params=None, **kwargs):
-        return self._client.get(self._client.api_host(), "/ni/basic/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        response = self._client.get(self._client.api_host(), "/ni/basic/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        self.check_for_error(response)
+
+        return response
 
     def get_standard_number_insight(self, params=None, **kwargs):
-        return self._client.get(self._client.api_host(), "/ni/standard/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        response = self._client.get(self._client.api_host(), "/ni/standard/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        self.check_for_error(response)
+
+        return response
 
     def get_advanced_number_insight(self, params=None, **kwargs):
-        return self._client.get(self._client.api_host(), "/ni/advanced/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        response = self._client.get(self._client.api_host(), "/ni/advanced/json", params or kwargs, auth_type=NumberInsight.auth_type)
+        self.check_for_error(response)
+
+        return response
 
     def get_async_advanced_number_insight(self, params=None, **kwargs):
         argoparams = params or kwargs
+        self.check_for_callback(argoparams)
+        
         if "callback" in argoparams and type(argoparams["callback"]) == str and argoparams["callback"] != "":
             return self._client.get(
                 self._client.api_host(), "/ni/advanced/async/json", params or kwargs, auth_type=NumberInsight.auth_type
@@ -26,3 +38,12 @@ class NumberInsight:
                 "A callback is needed for async advanced number insight"
             )
     
+    def check_for_error(self, response):
+        if response['status'] != 0:
+            raise NumberInsightError(f'Number Insight API method failed with status: {response["status"]} and error: {response["status_message"]}')
+
+    def check_for_callback(self, argoparams):
+        if not any("callback" in argoparams and type(argoparams["callback"]) == str and argoparams["callback"] != ""):
+            raise CallbackRequiredError(
+                "A callback is needed for async advanced number insight"
+            )

--- a/src/vonage/sms.py
+++ b/src/vonage/sms.py
@@ -31,19 +31,18 @@ class Sms:
         return response_data
 
     def check_for_partial_failure(self, response_data):
-        total_messages = int(response_data['message-count'])
         successful_messages = 0
+        total_messages = int(response_data['message-count'])
+        
         for message in response_data['messages']:
-            if int(message['status']) == 0:
+            if message['status'] == '0':
                 successful_messages += 1
-        if successful_messages == 0:
-            raise SmsError(f'Sms.send_message method failed with error: {response_data["messages"][0]["error-text"]}')
-        elif successful_messages < total_messages: 
-            raise PartialFailureError(f'Sms.send_message method partially failed. Not all of the message sent successfully.')
+        if successful_messages < total_messages: 
+            raise PartialFailureError('Sms.send_message method partially failed. Not all of the message sent successfully.')
 
     def check_for_failure(self, response_data):
         if int(response_data['messages'][0]['status']) != 0:
-                raise SmsError(f'Sms.send_message method failed with error: {response_data["messages"][0]["error-text"]}')
+                raise SmsError(f'Sms.send_message method failed with error code {response_data["messages"][0]["status"]}: {response_data["messages"][0]["error-text"]}')
     
     def submit_sms_conversion(self, message_id, delivered=True, timestamp=None):
         """

--- a/src/vonage/sms.py
+++ b/src/vonage/sms.py
@@ -41,8 +41,9 @@ class Sms:
             raise PartialFailureError('Sms.send_message method partially failed. Not all of the message sent successfully.')
 
     def check_for_failure(self, response_data):
-        if int(response_data['messages'][0]['status']) != 0:
-                raise SmsError(f'Sms.send_message method failed with error code {response_data["messages"][0]["status"]}: {response_data["messages"][0]["error-text"]}')
+        message = response_data['messages'][0]
+        if int(message['status']) != 0:
+                raise SmsError(f'Sms.send_message method failed with error code {message["status"]}: {message["error-text"]}')
     
     def submit_sms_conversion(self, message_id, delivered=True, timestamp=None):
         """

--- a/src/vonage/sms.py
+++ b/src/vonage/sms.py
@@ -1,7 +1,6 @@
 import pytz
 from datetime import datetime
 from ._internal import _format_date_param
-
 class Sms:
     defaults = {'auth_type': 'params', 'body_is_json': False}
 
@@ -14,13 +13,17 @@ class Sms:
         Requires a client initialized with `key` and either `secret` or `signature_secret`.
         :param dict params: A dict of values described at `Send an SMS <https://developer.vonage.com/api/sms#send-an-sms>`_
         """
-        return self._client.post(
+        response_data = self._client.post(
             self._client.host(), 
             "/sms/json", 
             params, 
             supports_signature_auth=True,
             **Sms.defaults,
         )
+
+        if response_data['messages'][0]['status'] != '0':
+            print(f'Sms.send_message method failed with error: {response_data["messages"][0]["error-text"]}')
+        return response_data
     
     def submit_sms_conversion(self, message_id, delivered=True, timestamp=None):
         """

--- a/src/vonage/sms.py
+++ b/src/vonage/sms.py
@@ -26,7 +26,7 @@ class Sms:
         if int(response_data['message-count']) > 1:
             self.check_for_partial_failure(response_data)
         else:
-            self.check_for_failure(response_data)
+            self.check_for_error(response_data)
 
         return response_data
 
@@ -40,7 +40,7 @@ class Sms:
         if successful_messages < total_messages: 
             raise PartialFailureError('Sms.send_message method partially failed. Not all of the message sent successfully.')
 
-    def check_for_failure(self, response_data):
+    def check_for_error(self, response_data):
         message = response_data['messages'][0]
         if int(message['status']) != 0:
                 raise SmsError(f'Sms.send_message method failed with error code {message["status"]}: {message["error-text"]}')

--- a/src/vonage/sms.py
+++ b/src/vonage/sms.py
@@ -1,6 +1,8 @@
 import pytz
 from datetime import datetime
 from ._internal import _format_date_param
+from .errors import SmsError
+
 class Sms:
     defaults = {'auth_type': 'params', 'body_is_json': False}
 
@@ -22,7 +24,8 @@ class Sms:
         )
 
         if response_data['messages'][0]['status'] != '0':
-            print(f'Sms.send_message method failed with error: {response_data["messages"][0]["error-text"]}')
+            raise SmsError(f'Sms.send_message method failed with error: {response_data["messages"][0]["error-text"]}')
+            
         return response_data
     
     def submit_sms_conversion(self, message_id, delivered=True, timestamp=None):

--- a/src/vonage/verify.py
+++ b/src/vonage/verify.py
@@ -1,4 +1,5 @@
-from .errors import VerifyError
+from .errors import VerifyError, BlockedNumberError
+
 
 class Verify:
     auth_type = 'params'
@@ -15,42 +16,67 @@ class Verify:
             **Verify.defaults,
         )
 
-        if 'error_text' in response:
-            raise VerifyError(response)
-
+        self.check_for_error(response)
         return response
 
-    def check(self, request_id, params=None, **kwargs):
-        return self._client.post(
+    def check(self, request_id, code):
+        response = self._client.post(
             self._client.api_host(),
             "/verify/check/json",
-            dict(params or kwargs, request_id=request_id),
+            {"request_id": request_id, "code": code},
             **Verify.defaults,
         )
 
-    def search(self, request_id):
-        return self._client.get(
-            self._client.api_host(), "/verify/search/json", {"request_id": request_id}, auth_type=Verify.auth_type
-        )
+        self.check_for_error(response)
+        return response
+
+    def search(self, request_id=None, request_ids=None):
+        if request_id:
+            response = self._client.get(
+                self._client.api_host(), "/verify/search/json", {"request_id": request_id}, auth_type=Verify.auth_type
+            )
+        elif request_ids:
+            response = self._client.get(
+                self._client.api_host(), "/verify/search/json", {"request_ids": request_ids}, auth_type=Verify.auth_type
+            )
+        else:
+            raise VerifyError('At least one request ID must be provided.')
+
+        self.check_for_error(response)
+        return response
 
     def cancel(self, request_id):
-        return self._client.post(
+        response = self._client.post(
             self._client.api_host(),
             "/verify/control/json",
             {"request_id": request_id, "cmd": "cancel"},
             **Verify.defaults,
         )
 
+        self.check_for_error(response)
+        return response
+
     def trigger_next_event(self, request_id):
-        return self._client.post(
+        response = self._client.post(
             self._client.api_host(),
             "/verify/control/json",
             {"request_id": request_id, "cmd": "trigger_next_event"},
             **Verify.defaults,
         )
 
+        self.check_for_error(response)
+        return response
+
     def psd2(self, params=None, **kwargs):
-        return self._client.post(
+        response = self._client.post(
             self._client.api_host(), "/verify/psd2/json", params or kwargs, **Verify.defaults,
         )
 
+        self.check_for_error(response)
+        return response
+
+    def check_for_error(self, response):
+        if response['status'] == '7':
+            raise BlockedNumberError('Error code 7: The number you are trying to verify is blocked for verification.')
+        elif 'error_text' in response:
+            raise VerifyError(f'Verify API method failed with status: {response["status"]} and error: {response["error_text"]}')

--- a/src/vonage/verify.py
+++ b/src/vonage/verify.py
@@ -30,14 +30,14 @@ class Verify:
         self.check_for_error(response)
         return response
 
-    def search(self, request_id=None, request_ids=None):
-        if request_id:
+    def search(self, request=None):
+        if type(request) == str:
             response = self._client.get(
-                self._client.api_host(), "/verify/search/json", {"request_id": request_id}, auth_type=Verify.auth_type
+                self._client.api_host(), "/verify/search/json", {"request_id": request}, auth_type=Verify.auth_type
             )
-        elif request_ids:
+        elif type(request) == list:
             response = self._client.get(
-                self._client.api_host(), "/verify/search/json", {"request_ids": request_ids}, auth_type=Verify.auth_type
+                self._client.api_host(), "/verify/search/json", {"request_ids": request}, auth_type=Verify.auth_type
             )
         else:
             raise VerifyError('At least one request ID must be provided.')

--- a/tests/data/number_insight/advanced_get.json
+++ b/tests/data/number_insight/advanced_get.json
@@ -1,0 +1,47 @@
+{
+    "status": 0,
+    "status_message": "Success",
+    "request_id": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+    "international_format_number": "447700900000",
+    "national_format_number": "07700 900000",
+    "country_code": "GB",
+    "country_code_iso3": "GBR",
+    "country_name": "United Kingdom",
+    "country_prefix": "44",
+    "request_price": "0.04000000",
+    "refund_price": "0.01500000",
+    "remaining_balance": "1.23456789",
+    "current_carrier": {
+      "network_code": "12345",
+      "name": "Acme Inc",
+      "country": "GB",
+      "network_type": "mobile"
+    },
+    "original_carrier": {
+      "network_code": "12345",
+      "name": "Acme Inc",
+      "country": "GB",
+      "network_type": "mobile"
+    },
+    "ported": "not_ported",
+    "roaming": {
+      "status": "roaming",
+      "roaming_country_code": "US",
+      "roaming_network_code": "12345",
+      "roaming_network_name": "Acme Inc"
+    },
+    "caller_identity": {
+      "caller_type": "consumer",
+      "caller_name": "John Smith",
+      "first_name": "John",
+      "last_name": "Smith"
+    },
+    "lookup_outcome": 0,
+    "lookup_outcome_message": "Success",
+    "valid_number": "valid",
+    "reachable": "reachable",
+    "real_time_data": {
+      "active_status": "true",
+      "handset_status": "On"
+    }
+}

--- a/tests/data/number_insight/basic_get.json
+++ b/tests/data/number_insight/basic_get.json
@@ -1,0 +1,11 @@
+{
+    "status": 0,
+    "status_message": "Success",
+    "request_id": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+    "international_format_number": "447700900000",
+    "national_format_number": "07700 900000",
+    "country_code": "GB",
+    "country_code_iso3": "GBR",
+    "country_name": "United Kingdom",
+    "country_prefix": "44"
+}

--- a/tests/data/number_insight/get_async_error.json
+++ b/tests/data/number_insight/get_async_error.json
@@ -1,0 +1,4 @@
+{
+    "status": 3,
+    "error_text": "Invalid request :: Not valid number format detected ['1234']"
+}

--- a/tests/data/number_insight/get_error.json
+++ b/tests/data/number_insight/get_error.json
@@ -1,0 +1,4 @@
+{
+    "status": 3,
+    "status_message": "Invalid request :: Not valid number format detected [ 1234 ]"
+}

--- a/tests/data/number_insight/standard_get.json
+++ b/tests/data/number_insight/standard_get.json
@@ -1,0 +1,37 @@
+{
+    "status": 0,
+    "status_message": "Success",
+    "request_id": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+    "international_format_number": "447700900000",
+    "national_format_number": "07700 900000",
+    "country_code": "GB",
+    "country_code_iso3": "GBR",
+    "country_name": "United Kingdom",
+    "country_prefix": "44",
+    "request_price": "0.04000000",
+    "refund_price": "0.01500000",
+    "remaining_balance": "1.23456789",
+    "current_carrier": {
+      "network_code": "12345",
+      "name": "Acme Inc",
+      "country": "GB",
+      "network_type": "mobile"
+    },
+    "original_carrier": {
+      "network_code": "12345",
+      "name": "Acme Inc",
+      "country": "GB",
+      "network_type": "mobile"
+    },
+    "ported": "not_ported",
+    "caller_identity": {
+      "caller_type": "consumer",
+      "caller_name": "John Smith",
+      "first_name": "John",
+      "last_name": "Smith"
+    },
+    "caller_name": "John Smith",
+    "last_name": "Smith",
+    "first_name": "John",
+    "caller_type": "consumer"
+}

--- a/tests/data/sms/long_message.txt
+++ b/tests/data/sms/long_message.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur tortor a est pretium scelerisque et nec tortor. Aliquam at rutrum dui. Proin iaculis urna sit amet volutpat sollicitudin.

--- a/tests/data/sms/send_long_message.json
+++ b/tests/data/sms/send_long_message.json
@@ -1,0 +1,21 @@
+{
+    "messages": [
+      {
+        "to": "447525856424",
+        "message-id": "b751970b-a923-45ce-b690-d590fc897a9d",
+        "status": "0",
+        "remaining-balance": "64.89226001",
+        "message-price": "0.04120000",
+        "network": "23420"
+      },
+      {
+        "to": "447525856424",
+        "message-id": "28304cb8-15b8-45e6-83b2-805c05364e1e",
+        "status": "0",
+        "remaining-balance": "64.89226001",
+        "message-price": "0.04120000",
+        "network": "23420"
+      }
+    ],
+    "message-count": "2"
+  }

--- a/tests/data/sms/send_long_message_partial_error.json
+++ b/tests/data/sms/send_long_message_partial_error.json
@@ -1,0 +1,17 @@
+{
+    "messages": [
+      {
+        "to": "447525856424",
+        "message-id": "b751970b-a923-45ce-b690-d590fc897a9d",
+        "status": "0",
+        "remaining-balance": "64.89226001",
+        "message-price": "0.04120000",
+        "network": "23420"
+      },
+      {        
+        "status": "5",
+        "error-text": "An internal error has occurred in the platform whilst processing this message"
+      }
+    ],
+    "message-count": "2"
+  }

--- a/tests/data/sms/send_message_200_error.json
+++ b/tests/data/sms/send_message_200_error.json
@@ -1,0 +1,9 @@
+{
+  "message-count": "1",
+  "messages": [
+    {        
+      "status": "2",
+      "error-text": "Missing to param"
+    }
+  ]
+}

--- a/tests/data/verify/blocked_with_network.json
+++ b/tests/data/verify/blocked_with_network.json
@@ -1,1 +1,0 @@
-{"status":"7","error_text":"The number you are trying to verify is blacklisted for verification","network":"25503"}

--- a/tests/data/verify/blocked_with_request_id.json
+++ b/tests/data/verify/blocked_with_request_id.json
@@ -1,1 +1,0 @@
-{"request_id":"12345678","status":"7","error_text":"The number you are trying to verify is blacklisted for verification"}

--- a/tests/data/verify/cancel_verification.json
+++ b/tests/data/verify/cancel_verification.json
@@ -1,0 +1,4 @@
+{
+    "status": "0",
+    "command": "cancel"
+}

--- a/tests/data/verify/check_verification.json
+++ b/tests/data/verify/check_verification.json
@@ -1,0 +1,8 @@
+{
+    "request_id": "abcdef0123456789abcdef0123456789",
+    "event_id": "0A00000012345678",
+    "status": "0",
+    "price": "0.10000000",
+    "currency": "EUR",
+    "estimated_price_messages_sent": "0.03330000"
+}

--- a/tests/data/verify/check_verification_error.json
+++ b/tests/data/verify/check_verification_error.json
@@ -1,0 +1,5 @@
+{
+    "request_id": "abcdef0123456789abcdef0123456789",
+    "status": "16",
+    "error_text": "The code inserted does not match the expected value"
+}

--- a/tests/data/verify/control_verification_error.json
+++ b/tests/data/verify/control_verification_error.json
@@ -1,0 +1,4 @@
+{
+    "status": "6",
+    "error_text": "The requestId 'asdf' does not exist or its no longer active."
+}

--- a/tests/data/verify/search_verification.json
+++ b/tests/data/verify/search_verification.json
@@ -1,0 +1,28 @@
+{
+    "request_id": "xxx",
+    "account_id": "abcdef01",
+    "status": "IN PROGRESS",
+    "number": "447700900000",
+    "price": "0.10000000",
+    "currency": "EUR",
+    "sender_id": "mySenderId",
+    "date_submitted": "2020-01-01 12:00:00",
+    "date_finalized": "2020-01-01 12:00:00",
+    "first_event_date": "2020-01-01 12:00:00",
+    "last_event_date": "2020-01-01 12:00:00",
+    "checks": [
+      {
+        "date_received": "2020-01-01 12:00:00",
+        "code": "987654",
+        "status": "abc123",
+        "ip_address": "123.0.0.255"
+      }
+    ],
+    "events": [
+      {
+        "type": "abc123",
+        "id": "abc123"
+      }
+    ],
+    "estimated_price_messages_sent": "0.03330000"
+}

--- a/tests/data/verify/search_verification_200_error.json
+++ b/tests/data/verify/search_verification_200_error.json
@@ -1,0 +1,5 @@
+{
+    "request_id": "xxx",
+    "status": "IN PROGRESS",
+    "error_text": "No response found"
+}

--- a/tests/data/verify/search_verification_multiple.json
+++ b/tests/data/verify/search_verification_multiple.json
@@ -1,0 +1,58 @@
+[    
+    {
+        "request_id": "xxx",
+        "account_id": "abcdef01",
+        "status": "IN PROGRESS",
+        "number": "447700900000",
+        "price": "0.10000000",
+        "currency": "EUR",
+        "sender_id": "mySenderId",
+        "date_submitted": "2020-01-01 12:00:00",
+        "date_finalized": "2020-01-01 12:00:00",
+        "first_event_date": "2020-01-01 12:00:00",
+        "last_event_date": "2020-01-01 12:00:00",
+        "checks": [
+        {
+            "date_received": "2020-01-01 12:00:00",
+            "code": "987654",
+            "status": "abc123",
+            "ip_address": "123.0.0.255"
+        }
+        ],
+        "events": [
+        {
+            "type": "abc123",
+            "id": "abc123"
+        }
+        ],
+        "estimated_price_messages_sent": "0.03330000"
+    },
+    {
+        "request_id": "yyy",
+        "account_id": "abcdef01",
+        "status": "IN PROGRESS",
+        "number": "447700900000",
+        "price": "0.10000000",
+        "currency": "EUR",
+        "sender_id": "mySenderId",
+        "date_submitted": "2020-01-01 12:00:00",
+        "date_finalized": "2020-01-01 12:00:00",
+        "first_event_date": "2020-01-01 12:00:00",
+        "last_event_date": "2020-01-01 12:00:00",
+        "checks": [
+        {
+            "date_received": "2020-01-01 12:00:00",
+            "code": "987654",
+            "status": "abc123",
+            "ip_address": "123.0.0.255"
+        }
+        ],
+        "events": [
+        {
+            "type": "abc123",
+            "id": "abc123"
+        }
+        ],
+        "estimated_price_messages_sent": "0.03330000"
+    }
+]

--- a/tests/data/verify/start_verification.json
+++ b/tests/data/verify/start_verification.json
@@ -1,0 +1,4 @@
+{
+    "request_id": "abcdef0123456789abcdef0123456789",
+    "status": "0"
+}

--- a/tests/data/verify/start_verification_error.json
+++ b/tests/data/verify/start_verification_error.json
@@ -1,0 +1,6 @@
+{
+    "request_id": "",
+    "status": "2",
+    "error_text": "Your request is incomplete and missing the mandatory parameter `number`",
+    "network": "244523"
+}

--- a/tests/data/verify/trigger_next_event.json
+++ b/tests/data/verify/trigger_next_event.json
@@ -1,0 +1,4 @@
+{
+    "status": "0",
+    "command": "trigger_next_event"
+}

--- a/tests/test_number_insight.py
+++ b/tests/test_number_insight.py
@@ -81,6 +81,17 @@ def test_get_async_advanced_number_insight(number_insight, dummy_data):
     assert "number=447525856424" in request_query()
     assert "callback=https%3A%2F%2Fexample.com" in request_query()
 
+
+@responses.activate
+def test_get_async_advanced_number_insight_error(number_insight):
+    stub(responses.GET, "https://api.nexmo.com/ni/advanced/async/json",
+        fixture_path='number_insight/get_async_error.json')
+
+    with pytest.raises(NumberInsightError) as err:
+        number_insight.get_async_advanced_number_insight(number='1234', callback='https://example.com')
+        assert str(err.value) == 'Number Insight API method failed with status: 3 and error: Invalid request :: Not valid number format detected [ 1234 ]'
+
+
 def test_callback_required_error_async_advanced_number_insight(number_insight, dummy_data):
     stub(responses.GET, "https://api.nexmo.com/ni/advanced/async/json")
 

--- a/tests/test_number_insight.py
+++ b/tests/test_number_insight.py
@@ -1,41 +1,82 @@
 from util import *
-from vonage.errors import CallbackRequiredError
+from vonage.errors import CallbackRequiredError, NumberInsightError
 
 
 @responses.activate
 def test_get_basic_number_insight(number_insight, dummy_data):
-    stub(responses.GET, "https://api.nexmo.com/ni/basic/json")
+    stub(responses.GET, "https://api.nexmo.com/ni/basic/json",
+        fixture_path='number_insight/basic_get.json')
 
-    assert isinstance(number_insight.get_basic_number_insight(number="447525856424"), dict)
+    response = number_insight.get_basic_number_insight(number='447700900000')
+    assert isinstance(response, dict)
+    assert response['status_message'] == 'Success'
     assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_query()
+    assert "number=447700900000" in request_query()
+
+
+@responses.activate
+def test_get_basic_number_insight_error(number_insight):
+    stub(responses.GET, "https://api.nexmo.com/ni/basic/json",
+        fixture_path='number_insight/get_error.json')
+
+    with pytest.raises(NumberInsightError) as err:
+        number_insight.get_basic_number_insight(number='1234')
+        assert str(err.value) == 'Number Insight API method failed with status: 3 and error: Invalid request :: Not valid number format detected [ 1234 ]'
 
 
 @responses.activate
 def test_get_standard_number_insight(number_insight, dummy_data):
-    stub(responses.GET, "https://api.nexmo.com/ni/standard/json")
+    stub(responses.GET, "https://api.nexmo.com/ni/standard/json",
+        fixture_path='number_insight/standard_get.json')
 
-    assert isinstance(number_insight.get_standard_number_insight(number="447525856424"), dict)
+    response = number_insight.get_standard_number_insight(number="447700900000")
+    assert isinstance(response, dict)
+    assert response['status_message'] == 'Success'
     assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_query()
+    assert "number=447700900000" in request_query()
+
+
+@responses.activate
+def test_get_standard_number_insight_error(number_insight):
+    stub(responses.GET, "https://api.nexmo.com/ni/standard/json",
+        fixture_path='number_insight/get_error.json')
+
+    with pytest.raises(NumberInsightError) as err:
+        number_insight.get_standard_number_insight(number='1234')
+        assert str(err.value) == 'Number Insight API method failed with status: 3 and error: Invalid request :: Not valid number format detected [ 1234 ]'
 
 
 @responses.activate
 def test_get_advanced_number_insight(number_insight, dummy_data):
-    stub(responses.GET, "https://api.nexmo.com/ni/advanced/json")
+    stub(responses.GET, "https://api.nexmo.com/ni/advanced/json",
+        fixture_path='number_insight/advanced_get.json')
 
-    assert isinstance(number_insight.get_advanced_number_insight(number="447525856424"), dict)
+    response = number_insight.get_advanced_number_insight(number="447700900000")
+    assert isinstance(response, dict)
+    assert response['status_message'] == 'Success'
     assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_query()
+    assert "number=447700900000" in request_query()
 
 
 @responses.activate
+def test_get_advanced_number_insight_error(number_insight):
+    stub(responses.GET, "https://api.nexmo.com/ni/advanced/json",
+        fixture_path='number_insight/get_error.json')
+
+    with pytest.raises(NumberInsightError) as err:
+        number_insight.get_advanced_number_insight(number='1234')
+        assert str(err.value) == 'Number Insight API method failed with status: 3 and error: Invalid request :: Not valid number format detected [ 1234 ]'
+
+@responses.activate
 def test_get_async_advanced_number_insight(number_insight, dummy_data):
-    stub(responses.GET, "https://api.nexmo.com/ni/advanced/async/json")
+    stub(responses.GET, "https://api.nexmo.com/ni/advanced/async/json",
+        fixture_path='number_insight/advanced_get.json')
 
     params = {"number": "447525856424", "callback": "https://example.com"}
 
-    assert isinstance(number_insight.get_async_advanced_number_insight(params), dict)
+    response = number_insight.get_async_advanced_number_insight(params)
+    assert isinstance(response, dict)
+    assert response['status_message'] == 'Success'
     assert request_user_agent() == dummy_data.user_agent
     assert "number=447525856424" in request_query()
     assert "callback=https%3A%2F%2Fexample.com" in request_query()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -67,7 +67,7 @@ def test_search_for_verification_multiple(verify, dummy_data):
     stub(responses.GET, "https://api.nexmo.com/verify/search/json",
         fixture_path="verify/search_verification.json")
 
-    response = verify.search(request_ids=['xxx', 'yyy'])
+    response = verify.search(request=['xxx', 'yyy'])
     assert isinstance(response, dict)
     assert response['status'] == 'IN PROGRESS'
     assert request_user_agent() == dummy_data.user_agent

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -107,14 +107,14 @@ def test_start_verification_blacklisted_error_with_network_and_request_id(client
     error_msg = "{'request_id': '12345678', 'status': '7', 'error_text': 'The number you are trying to verify is blacklisted for verification', 'network': '25503'}"
     
     with pytest.raises(VerifyError, match=error_msg):
-        client.verify.start_verification(params)
-    assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_body()
-    assert "brand=MyApp" in request_body()
-    assert response["status"] == "7"
-    assert response["network"] == "25503"
-    assert response["request_id"] == "12345678"
-    assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
+        response = client.verify.start_verification(params)
+        assert request_user_agent() == dummy_data.user_agent
+        assert "number=447525856424" in request_body()
+        assert "brand=MyApp" in request_body()
+        assert response["status"] == "7"
+        assert response["network"] == "25503"
+        assert response["request_id"] == "12345678"
+        assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
 
 @responses.activate
 def test_start_psd2_verification_blacklisted_error_with_network(client, dummy_data):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,22 +1,38 @@
 from util import *
-from vonage.errors import VerifyError
+from vonage.errors import VerifyError, BlockedNumberError
 
 
 @responses.activate
 def test_start_verification(verify, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/json")
+    stub(responses.POST, "https://api.nexmo.com/verify/json", 
+        fixture_path="verify/start_verification.json")
 
     params = {"number": "447525856424", "brand": "MyApp"}
 
-    assert isinstance(verify.start_verification(params), dict)
+    response = verify.start_verification(params)
+    assert isinstance(response, dict)
     assert request_user_agent() == dummy_data.user_agent
     assert "number=447525856424" in request_body()
     assert "brand=MyApp" in request_body()
+    assert response['status'] == '0'
+
+
+@responses.activate
+def test_start_verification_error(verify):
+    stub(responses.POST, "https://api.nexmo.com/verify/json", 
+        fixture_path="verify/start_verification_error.json")
+
+    params = {"number": "447525856424", "brand": "MyApp"}
+
+    with pytest.raises(VerifyError) as err:
+        assert isinstance(verify.start_verification(params), dict)
+        assert str(err.value) == 'Verify API method failed with error code 2: Your request is incomplete and missing the mandatory parameter `number`'
 
 
 @responses.activate
 def test_check_verification(verify, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/check/json")
+    stub(responses.POST, "https://api.nexmo.com/verify/check/json",
+        fixture_path="verify/check_verification.json")
 
     assert isinstance(verify.check("8g88g88eg8g8gg9g90", code="123445"), dict)
     assert request_user_agent() == dummy_data.user_agent
@@ -25,37 +41,128 @@ def test_check_verification(verify, dummy_data):
 
 
 @responses.activate
-def test_get_verification(verify, dummy_data):
-    stub(responses.GET, "https://api.nexmo.com/verify/search/json")
+def test_check_verification_error(verify):
+    stub(responses.POST, "https://api.nexmo.com/verify/check/json",
+        fixture_path="verify/check_verification_error.json")
 
-    assert isinstance(verify.search("xxx"), dict)
+    with pytest.raises(VerifyError) as err:
+        assert isinstance(verify.check("8g88g88eg8g8gg9g90", code="123445"), dict)
+        assert str(err.value) == 'Verify.start_verification method failed with error code 16: The code inserted does not match the expected value'
+
+
+@responses.activate
+def test_search_for_verification(verify, dummy_data):
+    stub(responses.GET, "https://api.nexmo.com/verify/search/json",
+        fixture_path="verify/search_verification.json")
+
+    response = verify.search('xxx')
+    assert isinstance(response, dict)
+    assert response['status'] == 'IN PROGRESS'
     assert request_user_agent() == dummy_data.user_agent
     assert "request_id=xxx" in request_query()
 
 
 @responses.activate
-def test_cancel_verification(verify, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/control/json")
+def test_search_for_verification_multiple(verify, dummy_data):
+    stub(responses.GET, "https://api.nexmo.com/verify/search/json",
+        fixture_path="verify/search_verification.json")
 
-    assert isinstance(verify.cancel("8g88g88eg8g8gg9g90"), dict)
+    response = verify.search(request_ids=['xxx', 'yyy'])
+    assert isinstance(response, dict)
+    assert response['status'] == 'IN PROGRESS'
+    assert request_user_agent() == dummy_data.user_agent
+    assert "request_ids=xxx&request_ids=yyy" in request_query()
+
+
+@responses.activate
+def test_search_for_verification_200_error(verify):
+    stub(responses.GET, "https://api.nexmo.com/verify/search/json",
+        fixture_path="verify/search_verification_200_error.json")
+    
+    with pytest.raises(VerifyError) as err:
+        verify.search('xxx')
+        assert str(err.value) == 'Verify API method failed with status: IN PROGRESS and error: No response found'
+
+
+@responses.activate
+def test_search_for_verification_error_no_id_provided(verify, dummy_data):
+    stub(responses.GET, "https://api.nexmo.com/verify/search/json")
+    
+    with pytest.raises(VerifyError) as err:
+        verify.search()
+        assert str(err.value) == 'At least one request ID must be provided.'
+
+
+@responses.activate
+def test_cancel_verification(verify, dummy_data):
+    stub(responses.POST, "https://api.nexmo.com/verify/control/json",
+        fixture_path='verify/cancel_verification.json')
+
+    response = verify.cancel('asdf')
+    assert isinstance(response, dict)
+    assert response['command'] == 'cancel'
     assert request_user_agent() == dummy_data.user_agent
     assert "cmd=cancel" in request_body()
-    assert "request_id=8g88g88eg8g8gg9g90" in request_body()
+    assert "request_id=asdf" in request_body()
+
+
+@responses.activate
+def test_cancel_verification_error(verify, dummy_data):
+    stub(responses.POST, "https://api.nexmo.com/verify/control/json",
+        fixture_path="verify/control_verification_error.json")
+
+    with pytest.raises(VerifyError) as err:
+        verify.cancel("asdf")
+        assert str(err.value) == "Verify API method failed with status: 6 and error: The requestId 'asdf' does not exist or its no longer active."
 
 
 @responses.activate
 def test_trigger_next_verification_event(verify, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/control/json")
+    stub(responses.POST, "https://api.nexmo.com/verify/control/json",
+        fixture_path='verify/trigger_next_event.json')
 
-    assert isinstance(verify.trigger_next_event("8g88g88eg8g8gg9g90"), dict)
+    response = verify.trigger_next_event("asdf")
+    assert isinstance(response, dict)
+    assert response['command'] == 'trigger_next_event'
     assert request_user_agent() == dummy_data.user_agent
     assert "cmd=trigger_next_event" in request_body()
-    assert "request_id=8g88g88eg8g8gg9g90" in request_body()
+    assert "request_id=asdf" in request_body()
+
+
+@responses.activate
+def test_trigger_next_verification_event_error(verify):
+    stub(responses.POST, "https://api.nexmo.com/verify/control/json",
+        fixture_path='verify/control_verification_error.json')
+
+    with pytest.raises(VerifyError) as err:
+        verify.trigger_next_event("asdf")
+        assert str(err.value) == "Verify API method failed with status: 6 and error: The requestId 'asdf' does not exist or its no longer active."
+
+
+@responses.activate
+def test_start_verification_blacklisted_error_with_network_and_request_id(client, dummy_data):
+    stub(responses.POST, "https://api.nexmo.com/verify/json",
+        fixture_path="verify/blocked_with_network_and_request_id.json"
+    )
+
+    params = {"number": "447525856424", "brand": "MyApp"}
+    error_msg = "Error code 7: The number you are trying to verify is blocked for verification."
+    
+    with pytest.raises(BlockedNumberError, match=error_msg):
+        response = client.verify.start_verification(params)
+        assert request_user_agent() == dummy_data.user_agent
+        assert "number=447525856424" in request_body()
+        assert "brand=MyApp" in request_body()
+        assert response["status"] == "7"
+        assert response["network"] == "25503"
+        assert response["request_id"] == "12345678"
+        assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
 
 
 @responses.activate
 def test_start_psd2_verification(verify, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/psd2/json")
+    stub(responses.POST, "https://api.nexmo.com/verify/psd2/json",
+        fixture_path='verify/psd2_verification.json')
 
     params = {"number": "447525856424", "brand": "MyApp"}
 
@@ -66,90 +173,16 @@ def test_start_psd2_verification(verify, dummy_data):
 
 
 @responses.activate
-def test_start_verification_blacklisted_error_with_network(client, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/json",
-        fixture_path="verify/blocked_with_network.json"
-    )
-
-    params = {"number": "447525856424", "brand": "MyApp"}
-    error_msg = "{'status': '7', 'error_text': 'The number you are trying to verify is blacklisted for verification', 'network': '25503'}"
-    
-    with pytest.raises(VerifyError, match=error_msg):
-        client.verify.start_verification(params)
-    assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_body()
-    assert "brand=MyApp" in request_body()
-
-
-@responses.activate
-def test_start_verification_blacklisted_error_with_request_id(client, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/json",
-        fixture_path="verify/blocked_with_request_id.json"
-    )
-
-    params = {"number": "447525856424", "brand": "MyApp"}
-    error_msg = "{'request_id': '12345678', 'status': '7', 'error_text': 'The number you are trying to verify is blacklisted for verification'}"
-    
-    with pytest.raises(VerifyError, match=error_msg):
-        client.verify.start_verification(params)
-    assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_body()
-    assert "brand=MyApp" in request_body()
-
-
-@responses.activate
-def test_start_verification_blacklisted_error_with_network_and_request_id(client, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/json",
-        fixture_path="verify/blocked_with_network_and_request_id.json"
-    )
-
-    params = {"number": "447525856424", "brand": "MyApp"}
-    error_msg = "{'request_id': '12345678', 'status': '7', 'error_text': 'The number you are trying to verify is blacklisted for verification', 'network': '25503'}"
-    
-    with pytest.raises(VerifyError, match=error_msg):
-        response = client.verify.start_verification(params)
-        assert request_user_agent() == dummy_data.user_agent
-        assert "number=447525856424" in request_body()
-        assert "brand=MyApp" in request_body()
-        assert response["status"] == "7"
-        assert response["network"] == "25503"
-        assert response["request_id"] == "12345678"
-        assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
-
-@responses.activate
-def test_start_psd2_verification_blacklisted_error_with_network(client, dummy_data):
+def test_start_psd2_verification_error(verify, dummy_data):
     stub(responses.POST, "https://api.nexmo.com/verify/psd2/json",
-        fixture_path="verify/blocked_with_network.json"
-    )
+        fixture_path='verify/psd2_verification_error.json')
 
     params = {"number": "447525856424", "brand": "MyApp"}
-    response = client.verify.psd2(params)
 
-    assert isinstance(response, dict)
+    assert isinstance(verify.psd2(params), dict)
     assert request_user_agent() == dummy_data.user_agent
     assert "number=447525856424" in request_body()
     assert "brand=MyApp" in request_body()
-    assert response["status"] == "7"
-    assert response["network"] == "25503"
-    assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
-
-
-@responses.activate
-def test_start_psd2_verification_blacklisted_error_with_request_id(client, dummy_data):
-    stub(responses.POST, "https://api.nexmo.com/verify/psd2/json",
-        fixture_path="verify/blocked_with_request_id.json"
-    )
-
-    params = {"number": "447525856424", "brand": "MyApp"}
-    response = client.verify.psd2(params)
-
-    assert isinstance(response, dict)
-    assert request_user_agent() == dummy_data.user_agent
-    assert "number=447525856424" in request_body()
-    assert "brand=MyApp" in request_body()
-    assert response["status"] == "7"
-    assert response["request_id"] == "12345678"
-    assert response["error_text"] == "The number you are trying to verify is blacklisted for verification"
 
 
 @responses.activate


### PR DESCRIPTION
This PR adds new exception classes, which are used in the case of APIs returning status 200 but there being an error. The Sms, Verify and NumberInsight classes have new methods and exceptions to deal with this situation.

This PR also adds the ability for a user to search for single or multiple verification requests by specifying either the `request` argument as a single string, or alternatively passing in a list of strings into the `request` argument.