### PR TITLE
deprecating pay ncco action

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,6 @@ Use the builder to construct valid NCCO actions, which are modelled in the SDK a
 * Stream
 * Input
 * Notify
-* Pay
 
 ### Construct actions
 

--- a/src/vonage/ncco_builder/ncco.py
+++ b/src/vonage/ncco_builder/ncco.py
@@ -6,6 +6,8 @@ from .connect_endpoints import ConnectEndpoints
 from .input_types import InputTypes
 from .pay_prompts import PayPrompts
 
+from deprecated import deprecated
+
 
 class Ncco:
     class Action(BaseModel):
@@ -171,6 +173,7 @@ class Ncco:
         def ensure_url_in_list(cls, v):
             return Ncco._ensure_object_in_list(v)
 
+    @deprecated(version='3.2.3', reason='The Pay NCCO action has been deprecated.')
     class Pay(Action):
         """The pay action collects credit card information with DTMF input in a secure (PCI-DSS compliant) way."""
 


### PR DESCRIPTION
This deprecates the Pay NCCO action as it's being removed from the Voice API. It will be removed in the next major release.