### PR TITLE
subclassing the ClientError class for SDK exceptions

### DIFF
--- a/src/vonage/errors.py
+++ b/src/vonage/errors.py
@@ -10,70 +10,70 @@ class AuthenticationError(ClientError):
     pass
 
 
-class CallbackRequiredError(Exception):
+class CallbackRequiredError(ClientError):
     """Indicates a callback is required but was not present."""
 
 
-class MessagesError(Exception):
+class MessagesError(ClientError):
     """
     Indicates an error related to the Messages class which calls the Vonage Messages API.
     """
 
 
-class SmsError(Exception):
+class SmsError(ClientError):
     """
     Indicates an error related to the Sms class which calls the Vonage SMS API.
     """
 
 
-class PartialFailureError(Exception):
+class PartialFailureError(ClientError):
     """
     Indicates that one or more parts of the message was not sent successfully.
     """
 
 
-class PricingTypeError(Exception):
+class PricingTypeError(ClientError):
     """A pricing type was specified that is not allowed."""
 
 
-class RedactError(Exception):
+class RedactError(ClientError):
 
     """Error related to the Redact class or Redact API."""
 
 
-class InvalidAuthenticationTypeError(Exception):
+class InvalidAuthenticationTypeError(ClientError):
     """An authentication method was specified that is not allowed."""
 
 
-class InvalidRoleError(Exception):
+class InvalidRoleError(ClientError):
     """The specified role was invalid."""
 
 
-class TokenExpiryError(Exception):
+class TokenExpiryError(ClientError):
     """The specified token expiry time was invalid."""
 
 
-class InvalidOptionsError(Exception):
+class InvalidOptionsError(ClientError):
     """The option(s) that were specified are invalid."""
 
     """An authentication method was specified that is not allowed."""
 
 
-class VerifyError(Exception):
+class VerifyError(ClientError):
     """Error related to the Verify API."""
 
 
-class BlockedNumberError(Exception):
+class BlockedNumberError(ClientError):
     """The number you are trying to verify is blocked for verification."""
 
 
-class NumberInsightError(Exception):
+class NumberInsightError(ClientError):
     """Error related to the Number Insight API."""
 
 
-class SipError(Exception):
+class SipError(ClientError):
     """Error related to usage of SIP calls."""
 
 
-class InvalidInputError(Exception):
+class InvalidInputError(ClientError):
     """The input that was provided was invalid."""


### PR DESCRIPTION
Historically we've subclassed a generic custom `Error` class. The exceptions related to use of the SDK should be subclasses of the `ClientError` exception, which is consistent with other Vonage server SDKs.