### PR TITLE
changing numbers API to use header authentication

### DIFF
--- a/src/vonage/client.py
+++ b/src/vonage/client.py
@@ -25,6 +25,7 @@ import time
 import re
 from uuid import uuid4
 
+from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 
@@ -269,7 +270,7 @@ class Client:
         logger.debug(f"DELETE to {repr(uri)} with headers {repr(self._request_headers)}")
         return self.parse(host, self.session.delete(uri, headers=self._request_headers, timeout=self.timeout))
 
-    def parse(self, host, response):
+    def parse(self, host, response: Response):
         logger.debug(f"Response headers {repr(response.headers)}")
         if response.status_code == 401:
             raise AuthenticationError("Authentication failed. Check you're using a valid authentication method.")

--- a/src/vonage/number_management.py
+++ b/src/vonage/number_management.py
@@ -1,32 +1,26 @@
 class Numbers:
-    auth_type = 'params'
+    auth_type = 'header'
     defaults = {'auth_type': auth_type, 'body_is_json': False}
 
     def __init__(self, client):
         self._client = client
-        
+
     def get_account_numbers(self, params=None, **kwargs):
         return self._client.get(self._client.host(), "/account/numbers", params or kwargs, auth_type=Numbers.auth_type)
 
     def get_available_numbers(self, country_code, params=None, **kwargs):
         return self._client.get(
-            self._client.host(), 
-            "/number/search", 
-            dict(params or kwargs, country=country_code), 
-            auth_type=Numbers.auth_type
+            self._client.host(),
+            "/number/search",
+            dict(params or kwargs, country=country_code),
+            auth_type=Numbers.auth_type,
         )
 
     def buy_number(self, params=None, **kwargs):
-        return self._client.post(
-            self._client.host(), "/number/buy", params or kwargs, **Numbers.defaults
-        )
+        return self._client.post(self._client.host(), "/number/buy", params or kwargs, **Numbers.defaults)
 
     def cancel_number(self, params=None, **kwargs):
-        return self._client.post(
-            self._client.host(), "/number/cancel", params or kwargs, **Numbers.defaults
-        )
+        return self._client.post(self._client.host(), "/number/cancel", params or kwargs, **Numbers.defaults)
 
     def update_number(self, params=None, **kwargs):
-        return self._client.post(
-            self._client.host(), "/number/update", params or kwargs, **Numbers.defaults
-        )
+        return self._client.post(self._client.host(), "/number/update", params or kwargs, **Numbers.defaults)


### PR DESCRIPTION
The numbers api now uses header authentication instead of query parameter authentication.

Have added a type hint to the response to allow for easier debugging

Blackened the file