### PR TITLE
adding advancedMachineDetection to ncco builder and testing

### DIFF
--- a/src/vonage/ncco_builder/ncco.py
+++ b/src/vonage/ncco_builder/ncco.py
@@ -110,10 +110,6 @@ class Ncco:
                 raise ValueError('advancedMachineDetection["behavior"] must be one of: "continue", "hangup".')
             if 'mode' in v and v['mode'] not in ('detect, detect_beep'):
                 raise ValueError('advancedMachineDetection["mode"] must be one of: "detect", "detect_beep".')
-            if 'beep_timeout' in v and type(v['beep_timeout']) != int:
-                raise ValueError('advancedMachineDetection["beep_timeout"] must be an integer.')
-            if 'beep_timeout' in v and (v['beep_timeout'] < 45 or v['beep_timeout'] > 120):
-                raise ValueError('advancedMachineDetection["beep_timeout"] must be >= 45 or <= 120.')
             return v
 
         class Config:

--- a/src/vonage/ncco_builder/ncco.py
+++ b/src/vonage/ncco_builder/ncco.py
@@ -73,6 +73,7 @@ class Ncco:
         timeout: Optional[int]
         limit: Optional[conint(le=7200)]
         machineDetection: Optional[Literal['continue', 'hangup']]
+        advancedMachineDetection: Optional[dict]
         eventUrl: Optional[Union[List[str], str]]
         eventMethod: Optional[constr(to_upper=True)]
         ringbackTone: Optional[str]
@@ -102,6 +103,18 @@ class Ncco:
         @validator('eventUrl')
         def ensure_url_in_list(cls, v):
             return Ncco._ensure_object_in_list(v)
+
+        @validator('advancedMachineDetection')
+        def validate_advancedMachineDetection(cls, v):
+            if 'behavior' in v and v['behavior'] not in ('continue', 'hangup'):
+                raise ValueError('advancedMachineDetection["behavior"] must be one of: "continue", "hangup".')
+            if 'mode' in v and v['mode'] not in ('detect, detect_beep'):
+                raise ValueError('advancedMachineDetection["mode"] must be one of: "detect", "detect_beep".')
+            if 'beep_timeout' in v and type(v['beep_timeout']) != int:
+                raise ValueError('advancedMachineDetection["beep_timeout"] must be an integer.')
+            if 'beep_timeout' in v and (v['beep_timeout'] < 45 or v['beep_timeout'] > 120):
+                raise ValueError('advancedMachineDetection["beep_timeout"] must be >= 45 or <= 120.')
+            return v
 
         class Config:
             smart_union = True

--- a/tests/test_ncco_builder/ncco_samples/ncco_action_samples.py
+++ b/tests/test_ncco_builder/ncco_samples/ncco_action_samples.py
@@ -22,7 +22,7 @@ connect_vbc = '{"action": "connect", "endpoint": [{"type": "vbc", "extension": "
 
 connect_full = '{"action": "connect", "endpoint": [{"type": "phone", "number": "447000000000"}], "from": "447400000000", "randomFromNumber": false, "eventType": "synchronous", "timeout": 15, "limit": 1000, "machineDetection": "hangup", "eventUrl": ["http://example.com"], "eventMethod": "PUT", "ringbackTone": "http://example.com"}'
 
-connect_advancedMachineDetection = '{"action": "connect", "endpoint": [{"type": "phone", "number": "447000000000"}], "from": "447400000000", "advancedMachineDetection": {"behavior": "continue", "mode": "detect", "beep_timeout": 45}, "eventUrl": ["http://example.com"]}'
+connect_advancedMachineDetection = '{"action": "connect", "endpoint": [{"type": "phone", "number": "447000000000"}], "from": "447400000000", "advancedMachineDetection": {"behavior": "continue", "mode": "detect"}, "eventUrl": ["http://example.com"]}'
 
 talk_basic = '{"action": "talk", "text": "hello"}'
 

--- a/tests/test_ncco_builder/ncco_samples/ncco_action_samples.py
+++ b/tests/test_ncco_builder/ncco_samples/ncco_action_samples.py
@@ -22,6 +22,8 @@ connect_vbc = '{"action": "connect", "endpoint": [{"type": "vbc", "extension": "
 
 connect_full = '{"action": "connect", "endpoint": [{"type": "phone", "number": "447000000000"}], "from": "447400000000", "randomFromNumber": false, "eventType": "synchronous", "timeout": 15, "limit": 1000, "machineDetection": "hangup", "eventUrl": ["http://example.com"], "eventMethod": "PUT", "ringbackTone": "http://example.com"}'
 
+connect_advancedMachineDetection = '{"action": "connect", "endpoint": [{"type": "phone", "number": "447000000000"}], "from": "447400000000", "advancedMachineDetection": {"behavior": "continue", "mode": "detect", "beep_timeout": 45}, "eventUrl": ["http://example.com"]}'
+
 talk_basic = '{"action": "talk", "text": "hello"}'
 
 talk_full = '{"action": "talk", "text": "hello", "bargeIn": true, "loop": 3, "level": 0.5, "language": "en-GB", "style": 1, "premium": true}'

--- a/tests/test_ncco_builder/ncco_samples/ncco_builder_samples.py
+++ b/tests/test_ncco_builder/ncco_samples/ncco_builder_samples.py
@@ -17,6 +17,12 @@ connect = Ncco.Connect(
     ringbackTone='http://example.com',
 )
 
+connect_advancedMachineDetection = Ncco.Connect(
+    endpoint=ConnectEndpoints.PhoneEndpoint(number='447000000000'),
+    advancedMachineDetection={'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45},
+)
+
+
 talk_minimal = Ncco.Talk(text='hello')
 
 talk = Ncco.Talk(text='hello', bargeIn=True, loop=3, level=0.5, language='en-GB', style=1, premium=True)
@@ -65,6 +71,16 @@ two_part_ncco = [
     {
         'action': 'record',
         'eventUrl': ['http://example.com/events'],
+    },
+    {'action': 'talk', 'text': 'hello'},
+]
+
+three_part_advancedMachineDetection_ncco = [
+    {'action': 'record', 'eventUrl': ['http://example.com/events']},
+    {
+        'action': 'connect',
+        'endpoint': [{'type': 'phone', 'number': '447000000000'}],
+        'advancedMachineDetection': {'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45},
     },
     {'action': 'talk', 'text': 'hello'},
 ]

--- a/tests/test_ncco_builder/ncco_samples/ncco_builder_samples.py
+++ b/tests/test_ncco_builder/ncco_samples/ncco_builder_samples.py
@@ -19,7 +19,7 @@ connect = Ncco.Connect(
 
 connect_advancedMachineDetection = Ncco.Connect(
     endpoint=ConnectEndpoints.PhoneEndpoint(number='447000000000'),
-    advancedMachineDetection={'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45},
+    advancedMachineDetection={'behavior': 'continue', 'mode': 'detect'},
 )
 
 
@@ -80,7 +80,7 @@ three_part_advancedMachineDetection_ncco = [
     {
         'action': 'connect',
         'endpoint': [{'type': 'phone', 'number': '447000000000'}],
-        'advancedMachineDetection': {'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45},
+        'advancedMachineDetection': {'behavior': 'continue', 'mode': 'detect'},
     },
     {'action': 'talk', 'text': 'hello'},
 ]

--- a/tests/test_ncco_builder/test_ncco_actions.py
+++ b/tests/test_ncco_builder/test_ncco_actions.py
@@ -125,6 +125,18 @@ def test_connect_options():
     assert json.dumps(_action_as_dict(connect)) == nas.connect_full
 
 
+def test_connect_advanced_machine_detection():
+    advancedMachineDetectionParams = {'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45}
+    endpoint = ConnectEndpoints.PhoneEndpoint(number='447000000000')
+    connect = Ncco.Connect(
+        endpoint=endpoint,
+        from_='447400000000',
+        advancedMachineDetection=advancedMachineDetectionParams,
+        eventUrl='http://example.com',
+    )
+    assert json.dumps(_action_as_dict(connect)) == nas.connect_advancedMachineDetection
+
+
 def test_connect_random_from_number_error():
     endpoint = ConnectEndpoints.PhoneEndpoint(number='447000000000')
     with pytest.raises(ValueError) as err:
@@ -143,6 +155,16 @@ def test_connect_validation_errors():
         Ncco.Connect(endpoint=endpoint, limit=7201)
     with pytest.raises(ValidationError):
         Ncco.Connect(endpoint=endpoint, machineDetection='do_nothing')
+    with pytest.raises(ValidationError):
+        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'behavior': 'do_nothing'})
+    with pytest.raises(ValidationError):
+        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'mode': 'detect_nothing'})
+    with pytest.raises(ValidationError):
+        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': '100'})
+    with pytest.raises(ValidationError):
+        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': 10})
+    with pytest.raises(ValidationError):
+        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': 1000})
 
 
 def test_talk_basic():

--- a/tests/test_ncco_builder/test_ncco_actions.py
+++ b/tests/test_ncco_builder/test_ncco_actions.py
@@ -126,7 +126,7 @@ def test_connect_options():
 
 
 def test_connect_advanced_machine_detection():
-    advancedMachineDetectionParams = {'behavior': 'continue', 'mode': 'detect', 'beep_timeout': 45}
+    advancedMachineDetectionParams = {'behavior': 'continue', 'mode': 'detect'}
     endpoint = ConnectEndpoints.PhoneEndpoint(number='447000000000')
     connect = Ncco.Connect(
         endpoint=endpoint,
@@ -159,12 +159,6 @@ def test_connect_validation_errors():
         Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'behavior': 'do_nothing'})
     with pytest.raises(ValidationError):
         Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'mode': 'detect_nothing'})
-    with pytest.raises(ValidationError):
-        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': '100'})
-    with pytest.raises(ValidationError):
-        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': 10})
-    with pytest.raises(ValidationError):
-        Ncco.Connect(endpoint=endpoint, advancedMachineDetection={'beep_timeout': 1000})
 
 
 def test_talk_basic():

--- a/tests/test_ncco_builder/test_ncco_builder.py
+++ b/tests/test_ncco_builder/test_ncco_builder.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 
 from vonage import Ncco
@@ -20,13 +19,9 @@ def test_build_ncco_from_args():
 
 
 def test_build_ncco_from_list():
-    action_list = [nbs.record, nbs.talk_minimal]
+    action_list = [nbs.record, nbs.connect_advancedMachineDetection, nbs.talk_minimal]
     ncco = Ncco.build_ncco(actions=action_list)
-    assert ncco == nbs.two_part_ncco
-    assert (
-        json.dumps(ncco)
-        == '[{"action": "record", "eventUrl": ["http://example.com/events"]}, {"action": "talk", "text": "hello"}]'
-    )
+    assert ncco == nbs.three_part_advancedMachineDetection_ncco
 
 
 def test_build_insane_ncco():


### PR DESCRIPTION
This PR adds `advancedMachineDetection` to the NCCO builder. It's already possible in the SDK manually but this allows a user to use the feature in conjunction with the NCCO builder.