### PR TITLE
Update fraud check

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.0
+current_version = 3.5.1
 commit = True
 tag = False
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 3.5.1
+- Updating the internal use of the `fraud_check` parameter in the Vonage Verify V2 API
+
 # 3.5.0
 - Adding support for V2 of the Vonage Verify API
     - Multiple authentication channels are supported (sms, voice, email, whatsapp, whatsapp interactive messages and silent authentication)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(
 
 setup(
     name="vonage",
-    version="3.5.0",
+    version="3.5.1",
     description="Vonage Server SDK for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/vonage/__init__.py
+++ b/src/vonage/__init__.py
@@ -1,4 +1,4 @@
 from .client import *
 from .ncco_builder.ncco import *
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"

--- a/src/vonage/verify2.py
+++ b/src/vonage/verify2.py
@@ -22,6 +22,7 @@ class Verify2:
         self._auth_type = 'jwt'
 
     def new_request(self, params: dict):
+        self._remove_unnecessary_fraud_check(params)
         try:
             params_to_verify = copy.deepcopy(params)
             Verify2.VerifyRequest.parse_obj(params_to_verify)
@@ -60,6 +61,10 @@ class Verify2:
             f'/v2/verify/{request_id}',
             auth_type=self._auth_type,
         )
+
+    def _remove_unnecessary_fraud_check(self, params):
+        if 'fraud_check' in params and params['fraud_check'] != False:
+            del params['fraud_check']
 
     class VerifyRequest(BaseModel):
         brand: str

--- a/tests/test_verify2.py
+++ b/tests/test_verify2.py
@@ -452,3 +452,10 @@ def test_cancel_verification_error_not_found():
         str(err.value)
         == "Not Found: Request 'c11236f4-00bf-4b89-84ba-88b25df97315' was not found or it has been verified already. (https://developer.nexmo.com/api-errors#not-found)"
     )
+
+
+def test_remove_unnecessary_fraud_check():
+    params = {'brand': 'ACME, Inc', 'workflow': [{'channel': 'sms', 'to': '447700900000'}], 'fraud_check': True}
+    verify2._remove_unnecessary_fraud_check(params)
+
+    assert 'fraud_check' not in params


### PR DESCRIPTION
This updates `Verify2.new_request` so the `fraud_check` parameter is only sent in the request payload when specifically set to False.