### PR TITLE
use Vonage JWT generator instead of PyJWT for requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ coverage:
 	coverage html
 
 test:
-	pytest -v
+	pytest -vv --disable-warnings
 
 clean:
 	rm -rf dist build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![PyPI version](https://badge.fury.io/py/vonage.svg)](https://badge.fury.io/py/vonage)
 [![Build Status](https://github.com/Vonage/vonage-python-sdk/workflows/Build/badge.svg)](https://github.com/Vonage/vonage-python-sdk/actions)
-[![codecov](https://codecov.io/gh/Vonage/vonage-python-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/Vonage/vonage-python-sdk)
 [![Python versions supported](https://img.shields.io/pypi/pyversions/vonage.svg)](https://pypi.python.org/pypi/vonage)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
@@ -728,34 +727,32 @@ your account before you can validate webhook signatures.
 
 ## JWT parameters
 
-By default, the library generates short-lived tokens for JWT authentication.
+By default, the library generates 15-minute tokens for JWT authentication.
 
-Use the auth method to specify parameters for a longer life token or to
-specify a different token identifier:
+Use the `auth` method of the client class to specify custom parameters:
 
 ```python
 client.auth(nbf=nbf, exp=exp, jti=jti)
+# OR
+client.auth({'nbf': nbf, 'exp': exp, 'jti': jti})
 ```
 
 ## Overriding API Attributes
 
-In order to rewrite/get the value of variables used across all the Vonage classes Python uses `Call by Object Reference` that allows you to create a single client for Sms/Voice Classes. This means that if you make a change on a client instance this will be available for the Sms class.
+In order to rewrite/get the value of variables used across all the Vonage classes Python uses `Call by Object Reference` that allows you to create a single client to use with all API classes.
 
 An example using setters/getters with `Object references`:
 
 ```python
-from vonage import Client, Sms
+from vonage import Client
 
-#Defines the client
+# Define the client
 client = Client(key='YOUR_API_KEY', secret='YOUR_API_SECRET')
 print(client.host()) # using getter for host -- value returned: rest.nexmo.com
 
-#Define the sms instance
-sms = Sms(client)
-
-#Change the value in client
-client.host('mio.nexmo.com') #Change host to mio.nexmo.com - this change will be available for sms
-
+# Change the value in client
+client.host('mio.nexmo.com') # Change host to mio.nexmo.com - this change will be available for sms
+client.sms.send_message(params) # Sends an SMS to the host above
 ```
 
 ### Overriding API Host / Host Attributes

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     package_dir={"": "src"},
     platforms=["any"],
     install_requires=[
+        "vonage-jwt>=1.0.0",
         "requests>=2.4.2",
-        "PyJWT[crypto]>=1.6.4",
         "pytz>=2018.5",
         "Deprecated",
         "pydantic>=1.10.2",

--- a/tests/test_getters_setters.py
+++ b/tests/test_getters_setters.py
@@ -1,24 +1,12 @@
-from util import *
-
-@responses.activate
 def test_getters(client, dummy_data):
     assert client.host() == dummy_data.host
     assert client.api_host() == dummy_data.api_host
 
-@responses.activate
 def test_setters(client, dummy_data):
     try:
-        client.host('host.nexmo.com')
-        client.api_host('host.nexmo.com')
+        client.host('host.vonage.com')
+        client.api_host('host.vonage.com')
         assert client.host() != dummy_data.host
         assert client.api_host() != dummy_data.api_host
     except:
         assert False
-
-@responses.activate
-def test_fail_setter_url_format(client, dummy_data):
-    try:
-        client.host('1000.1000')
-        assert False
-    except:
-        assert True

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,0 +1,39 @@
+from time import time
+from unittest.mock import patch
+
+now = int(time())
+
+
+def test_auth_sets_claims_from_kwargs(client):
+    client.auth(jti='asdfzxcv1234', nbf=now + 100, exp=now + 1000)
+    assert client._jwt_claims['jti'] == 'asdfzxcv1234'
+    assert client._jwt_claims['nbf'] == now + 100
+    assert client._jwt_claims['exp'] == now + 1000
+
+
+def test_auth_sets_claims_from_dict(client):
+    custom_jwt_claims = {'jti': 'asdfzxcv1234', 'nbf': now + 100, 'exp': now + 1000}
+    client.auth(custom_jwt_claims)
+    assert client._jwt_claims['jti'] == 'asdfzxcv1234'
+    assert client._jwt_claims['nbf'] == now + 100
+    assert client._jwt_claims['exp'] == now + 1000
+
+
+test_jwt = b'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBsaWNhdGlvbl9pZCI6ImFzZGYxMjM0IiwiaWF0IjoxNjg1NzMxMzkxLCJqdGkiOiIwYzE1MDJhZS05YmI5LTQ4YzQtYmQyZC0yOGFhNWUxYjZkMTkiLCJleHAiOjE2ODU3MzIyOTF9.mAkGeVgWOb7Mrzka7DSj32vSM8RaFpYse_2E7jCQ4DuH8i32wq9FxXGgfwdBQDHzgku3RYIjLM1xlVrGjNM3MsnZgR7ymQ6S4bdTTOmSK0dKbk91SrN7ZAC9k2a6JpCC2ZYgXpZ5BzpDTdy9BYu6msHKmkL79_aabFAhrH36Nk26pLvoI0-KiGImEex-aRR4iiaXhOebXBeqiQTRPKoKizREq4-8zBQv_j6yy4AiEYvBatQ8L_sjHsLj9jjITreX8WRvEW-G4TPpPLMaHACHTDMpJSOZAnegAkzTV2frVRmk6DyVXnemm4L0RQD1XZDaH7JPsKk24Hd2WZQyIgHOqQ'
+
+
+def vonage_jwt_mock(self, claims):
+    return test_jwt
+
+
+def test_generate_application_jwt(client):
+    with patch('vonage.client.JwtClient.generate_application_jwt', vonage_jwt_mock):
+        jwt = client._generate_application_jwt()
+    assert jwt == test_jwt
+
+
+def test_add_jwt_to_request_headers(client):
+    with patch('vonage.client.JwtClient.generate_application_jwt', vonage_jwt_mock):
+        headers = client._add_jwt_to_request_headers()
+    assert headers['Accept'] == 'application/json'
+    assert headers['Authorization'] == b'Bearer ' + test_jwt

--- a/tests/test_rest_calls.py
+++ b/tests/test_rest_calls.py
@@ -80,3 +80,12 @@ def test_delete_with_header_auth(client, dummy_data):
     assert isinstance(response, dict)
     assert request_user_agent() == dummy_data.user_agent
     assert_basic_auth()
+
+@responses.activate
+def test_get_with_jwt_auth(client, dummy_data):
+    stub(responses.GET, "https://api.nexmo.com/v1/calls")
+    host = "api.nexmo.com"
+    request_uri = "/v1/calls"
+    response = client.get(host, request_uri, auth_type='jwt')
+    assert isinstance(response, dict)
+    assert request_user_agent() == dummy_data.user_agent

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -139,21 +139,22 @@ def test_send_dtmf(voice, dummy_data):
 
 
 @responses.activate
-def test_user_provided_authorization(client, dummy_data):
+def test_user_provided_authorization(dummy_data):
     stub(responses.GET, "https://api.nexmo.com/v1/calls/xx-xx-xx-xx")
 
-    application_id = "different-nexmo-application-id"
+    application_id = "different-application-id"
+    client = vonage.Client(application_id=application_id, private_key=dummy_data.private_key)
+
     nbf = int(time.time())
     exp = nbf + 3600
-
-    client.auth(application_id=application_id, nbf=nbf, exp=exp)
-    voice = vonage.Voice(client)
-    voice.get_call("xx-xx-xx-xx")
+    
+    client.auth(nbf=nbf, exp=exp)
+    client.voice.get_call("xx-xx-xx-xx")
 
     token = request_authorization().split()[1]
 
     token = jwt.decode(token, dummy_data.public_key, algorithms="RS256")
-
+    print(token)
     assert token["application_id"] == application_id
     assert token["nbf"] == nbf
     assert token["exp"] == exp


### PR DESCRIPTION
Uses the new vonage jwt generator instead of PyJWT. Custom claims can be specified and it can also be used independently of the python sdk to generate jwts for use with vonage apis.

Refactoring, editing the readme, adding additional tests.