### PR TITLE
fix: change ncco websocket endpoint contentType to content-type

### DIFF
--- a/src/vonage/ncco_builder/connect_endpoints.py
+++ b/src/vonage/ncco_builder/connect_endpoints.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, HttpUrl, AnyUrl, constr, field_serializer
-from typing import Dict
+from pydantic import BaseModel, HttpUrl, AnyUrl, constr, field_serializer, Field
+from typing import Dict, Annotated
 from typing_extensions import Literal
 
 
@@ -29,7 +29,7 @@ class ConnectEndpoints:
         type: Literal['websocket'] = 'websocket'
 
         uri: AnyUrl
-        contentType: Literal['audio/l16;rate=16000', 'audio/l16;rate=8000']
+        contentType: Annotated[Literal['audio/l16;rate=16000', 'audio/l16;rate=8000'], Field(serialization_alias='content-type')]
         headers: dict = None
 
         @field_serializer('uri')


### PR DESCRIPTION
When using the NCCO builder to create a Websocket Connect Endpoint, it serializes to have a field 'contentType', whilst the API expects a field of 'content-type'

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->

{ "content-type": "...." }

## Current Behavior

{ "contentType": "...." }

## Possible Solution

### Code

```python
# Where BITRATE=16, and FREQUENCY=16000
ws = ConnectEndpoints.WebsocketEndpoint(
    uri=some_url,
    contentType=f"audio/l{StreamingConfig.BITRATE};rate={StreamingConfig.FREQUENCY}"
)

c = Ncco.Connect(endpoint=ws, eventType="synchronous")
ncco = Ncco.build_ncco(c)
print(json.dumps(ncco, indent=4))
```

### Response to Voice API

```json
[
    {
        "action": "connect",
        "endpoint": [
            {
                "type": "websocket",
                "uri": "wss://***.ngrok-free.app/ws",
                "contentType": "audio/l16;rate=8000"
            }
        ],
        "eventType": "synchronous"
    }
]
```

### Websocket Connected Message

```json
{
    "content-type": "audio/l16;rate=16000",
    "event": "websocket:connected"
}
```

## After Applying Fix

```json
{
    "content-type": "audio/l16;rate=8000",
    "event": "websocket:connected"
}
```

## Your Environment
* Version used: latest (bug can be seen in src)