### PR TITLE
feat: add specific error class when Sms.send_message is throttled

### DIFF
--- a/sms/src/vonage_sms/errors.py
+++ b/sms/src/vonage_sms/errors.py
@@ -15,3 +15,7 @@ class PartialFailureError(SmsError):
         )
         super().__init__(self.message)
         self.response = response
+
+
+class SmsThrottleError(SmsError):
+    """Indicates that the SMS requests are being throttled due to too many requests in a short period."""

--- a/sms/tests/data/send_sms_error_throttling.json
+++ b/sms/tests/data/send_sms_error_throttling.json
@@ -1,0 +1,9 @@
+{
+    "message-count": "1",
+    "messages": [
+        {
+            "status": "1",
+            "error-text": "You are sending SMS faster than the account limit."
+        }
+    ]
+}

--- a/sms/tests/test_sms.py
+++ b/sms/tests/test_sms.py
@@ -7,7 +7,7 @@ from vonage_http_client.auth import Auth
 from vonage_http_client.errors import HttpRequestError
 from vonage_http_client.http_client import HttpClient
 from vonage_sms import Sms
-from vonage_sms.errors import PartialFailureError, SmsError
+from vonage_sms.errors import PartialFailureError, SmsError, SmsThrottleError
 from vonage_sms.requests import SmsMessage
 
 from testutils import build_response
@@ -143,6 +143,17 @@ def test_send_message_error():
     except SmsError as err:
         assert (
             str(err) == 'Sms.send_message method failed with error code 7: Number barred.'
+        )
+
+@responses.activate
+def test_send_message_error_throttling():
+    build_response(path, 'POST', 'https://rest.nexmo.com/sms/json', 'send_sms_error_throttling.json')
+    message = SmsMessage(to='1234567890', from_='Acme Inc.', text='Hello, World!')
+    try:
+        sms.send(message)
+    except SmsThrottleError as err:
+        assert (
+            str(err) == 'Sms.send_message method failed due to throttling: You are sending SMS faster than the account limit.'
         )
 
 


### PR DESCRIPTION
Fixes #325 

2 things :
- I've developped this with Github Copilot enabled
- I've had issues running black locally, hopefully this is OK

Also you mentionned the use of the "timeout value", but I'm not familiar enough with the api, how can I retrieve it?