### PR TITLE
feat: Add Basic Auth support to Verify (legacy)

### DIFF
--- a/testutils/__init__.py
+++ b/testutils/__init__.py
@@ -1,4 +1,4 @@
-from .mock_auth import get_mock_api_key_auth, get_mock_jwt_auth
+from .mock_auth import get_mock_api_key_auth, get_mock_jwt_auth, get_base64_encoded_api_key_and_secret
 from .testutils import build_response
 
-__all__ = ['build_response', 'get_mock_api_key_auth', 'get_mock_jwt_auth']
+__all__ = ['build_response', 'get_mock_api_key_auth', 'get_mock_jwt_auth', 'get_base64_encoded_api_key_and_secret']

--- a/testutils/__init__.py
+++ b/testutils/__init__.py
@@ -1,4 +1,13 @@
-from .mock_auth import get_mock_api_key_auth, get_mock_jwt_auth, get_base64_encoded_api_key_and_secret
+from .mock_auth import (
+    get_base64_encoded_api_key_and_secret,
+    get_mock_api_key_auth,
+    get_mock_jwt_auth,
+)
 from .testutils import build_response
 
-__all__ = ['build_response', 'get_mock_api_key_auth', 'get_mock_jwt_auth', 'get_base64_encoded_api_key_and_secret']
+__all__ = [
+    'build_response',
+    'get_mock_api_key_auth',
+    'get_mock_jwt_auth',
+    'get_base64_encoded_api_key_and_secret',
+]

--- a/testutils/mock_auth.py
+++ b/testutils/mock_auth.py
@@ -1,5 +1,5 @@
-from os.path import dirname, join
 from base64 import b64encode
+from os.path import dirname, join
 
 from vonage_http_client.auth import Auth
 

--- a/testutils/mock_auth.py
+++ b/testutils/mock_auth.py
@@ -1,6 +1,10 @@
 from os.path import dirname, join
+from base64 import b64encode
 
 from vonage_http_client.auth import Auth
+
+test_api_key = 'test_api_key'
+test_api_secret = 'test_api_secret'
 
 
 def read_file(path):
@@ -10,10 +14,16 @@ def read_file(path):
         return input_file.read()
 
 
+def get_base64_encoded_api_key_and_secret():
+    """Return a base64 encoded string of the API key and secret."""
+
+    return b64encode(f'{test_api_key}:{test_api_secret}'.encode('utf-8')).decode('ascii')
+
+
 def get_mock_api_key_auth():
     """Return an Auth object with an API key and secret."""
 
-    return Auth(api_key='test_api_key', api_secret='test_api_secret')
+    return Auth(api_key=test_api_key, api_secret=test_api_secret)
 
 
 def get_mock_jwt_auth():

--- a/verify_legacy/src/vonage_verify_legacy/verify_legacy.py
+++ b/verify_legacy/src/vonage_verify_legacy/verify_legacy.py
@@ -31,7 +31,7 @@ class VerifyLegacy:
     def __init__(self, http_client: HttpClient) -> None:
         self._http_client = http_client
         self._sent_data_type = 'form'
-        self._auth_type = 'body'
+        self._auth_type = 'basic'
 
     @property
     def http_client(self) -> HttpClient:

--- a/verify_legacy/tests/test_verify_legacy.py
+++ b/verify_legacy/tests/test_verify_legacy.py
@@ -10,7 +10,7 @@ from vonage_verify_legacy.requests import Psd2Request, VerifyRequest
 from vonage_verify_legacy.responses import NetworkUnblockStatus, VerifyControlStatus
 from vonage_verify_legacy.verify_legacy import VerifyLegacy
 
-from testutils import build_response, get_mock_api_key_auth
+from testutils import build_response, get_mock_api_key_auth, get_base64_encoded_api_key_and_secret
 
 path = abspath(__file__)
 
@@ -30,6 +30,12 @@ data = {
 def test_http_client_property():
     verify = VerifyLegacy(HttpClient(get_mock_api_key_auth()))
     assert isinstance(verify.http_client, HttpClient)
+
+
+@responses.activate
+def test_default_auth_type():
+    verify = VerifyLegacy(HttpClient(get_mock_api_key_auth()))
+    assert verify._auth_type == 'basic'
 
 
 def test_create_verify_request_model():
@@ -67,6 +73,9 @@ def test_make_verify_request():
     assert response.request_id == 'abcdef0123456789abcdef0123456789'
     assert response.status == '0'
 
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+
 
 @responses.activate
 def test_make_psd2_request():
@@ -79,6 +88,9 @@ def test_make_psd2_request():
     response = verify.start_psd2_verification(request)
     assert response.request_id == 'abcdef0123456789abcdef0123456789'
     assert response.status == '0'
+
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
 
 
 @responses.activate
@@ -129,6 +141,9 @@ def test_check_code():
     assert response.currency == 'EUR'
     assert response.estimated_price_messages_sent == '0.04675'
 
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+
 
 @responses.activate
 def test_check_code_error():
@@ -170,6 +185,9 @@ def test_search():
     assert response.events[0].type == 'sms'
     assert response.events[0].id == '23f3a13d-6d03-4262-8f4d-67f12a56e1c8'
 
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+
 
 @responses.activate
 def test_search_list_of_ids():
@@ -186,6 +204,9 @@ def test_search_list_of_ids():
     assert response1.request_id == 'c5037cb8b47449158ed6611afde58990'
     assert response1.status == 'SUCCESS'
     assert response1.checks[0].status == 'VALID'
+
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
 
 
 @responses.activate
@@ -216,6 +237,9 @@ def test_cancel_verification():
     assert type(response) == VerifyControlStatus
     assert response.status == '0'
     assert response.command == 'cancel'
+
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
 
 
 @responses.activate
@@ -248,6 +272,9 @@ def test_trigger_next_event():
     assert type(response) == VerifyControlStatus
     assert response.status == '0'
     assert response.command == 'trigger_next_event'
+
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
 
 
 @responses.activate
@@ -282,6 +309,9 @@ def test_request_network_unblock():
     assert type(response) == NetworkUnblockStatus
     assert response.network == '23410'
     assert response.unblocked_until == '2024-04-22T08:34:58Z'
+
+    request_headers = responses.calls[0].request.headers
+    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
 
 
 @responses.activate

--- a/verify_legacy/tests/test_verify_legacy.py
+++ b/verify_legacy/tests/test_verify_legacy.py
@@ -10,7 +10,11 @@ from vonage_verify_legacy.requests import Psd2Request, VerifyRequest
 from vonage_verify_legacy.responses import NetworkUnblockStatus, VerifyControlStatus
 from vonage_verify_legacy.verify_legacy import VerifyLegacy
 
-from testutils import build_response, get_mock_api_key_auth, get_base64_encoded_api_key_and_secret
+from testutils import (
+    build_response,
+    get_base64_encoded_api_key_and_secret,
+    get_mock_api_key_auth,
+)
 
 path = abspath(__file__)
 
@@ -74,7 +78,10 @@ def test_make_verify_request():
     assert response.status == '0'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -90,7 +97,10 @@ def test_make_psd2_request():
     assert response.status == '0'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -142,7 +152,10 @@ def test_check_code():
     assert response.estimated_price_messages_sent == '0.04675'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -186,7 +199,10 @@ def test_search():
     assert response.events[0].id == '23f3a13d-6d03-4262-8f4d-67f12a56e1c8'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -206,7 +222,10 @@ def test_search_list_of_ids():
     assert response1.checks[0].status == 'VALID'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -239,7 +258,10 @@ def test_cancel_verification():
     assert response.command == 'cancel'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -274,7 +296,10 @@ def test_trigger_next_event():
     assert response.command == 'trigger_next_event'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate
@@ -311,7 +336,10 @@ def test_request_network_unblock():
     assert response.unblocked_until == '2024-04-22T08:34:58Z'
 
     request_headers = responses.calls[0].request.headers
-    assert request_headers["Authorization"] == "Basic " + get_base64_encoded_api_key_and_secret()
+    assert (
+        request_headers["Authorization"]
+        == "Basic " + get_base64_encoded_api_key_and_secret()
+    )
 
 
 @responses.activate


### PR DESCRIPTION
This PR updates the implementation for Verify v1 (legacy) to use Basic Auth instead of key and secret params auth.