### PR TITLE
fix: Messages API Validations -- May 2026

### DIFF
--- a/messages/src/vonage_messages/models/rcs.py
+++ b/messages/src/vonage_messages/models/rcs.py
@@ -178,8 +178,12 @@ class RcsOptionsCard(RcsOptions):
 
     @model_validator(mode='after')
     def horizontal_orientation_requires_image_alignment(self):
-        """Validate that if the card orientation is horizontal, the image alignment is also specified."""
-        if self.card_orientation == RcsCardOrientation.HORIZONTAL and not self.image_alignment:
+        """Validate that if the card orientation is horizontal, the image alignment is
+        also specified."""
+        if (
+            self.card_orientation == RcsCardOrientation.HORIZONTAL
+            and not self.image_alignment
+        ):
             raise ValueError(
                 'image_alignment must be specified when card_orientation is HORIZONTAL'
             )
@@ -366,7 +370,8 @@ class RcsCardMessage(BaseRcs):
 
     @model_validator(mode='after')
     def vertical_orientation_requires_media_height(self):
-        """Validate that if the card orientation is vertical, the media height is also specified."""
+        """Validate that if the card orientation is vertical, the media height is also
+        specified."""
         if self.rcs and self.rcs.card_orientation == RcsCardOrientation.VERTICAL:
             if not self.card.media_height:
                 raise ValueError(

--- a/messages/src/vonage_messages/models/rcs.py
+++ b/messages/src/vonage_messages/models/rcs.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from vonage_utils.types import PhoneNumber
 
 from .base_message import BaseMessage
@@ -175,6 +175,15 @@ class RcsOptionsCard(RcsOptions):
 
     card_orientation: Optional[RcsCardOrientation] = None
     image_alignment: Optional[RcsImageAlignment] = None
+
+    @model_validator(mode='after')
+    def horizontal_orientation_requires_image_alignment(self):
+        """Validate that if the card orientation is horizontal, the image alignment is also specified."""
+        if self.card_orientation == RcsCardOrientation.HORIZONTAL and not self.image_alignment:
+            raise ValueError(
+                'image_alignment must be specified when card_orientation is HORIZONTAL'
+            )
+        return self
 
 
 class RcsOptionsCarousel(RcsOptions):
@@ -354,6 +363,16 @@ class RcsCardMessage(BaseRcs):
     card: RcsCard
     rcs: Optional[RcsOptionsCard] = None
     message_type: MessageType = MessageType.CARD
+
+    @model_validator(mode='after')
+    def vertical_orientation_requires_media_height(self):
+        """Validate that if the card orientation is vertical, the media height is also specified."""
+        if self.rcs and self.rcs.card_orientation == RcsCardOrientation.VERTICAL:
+            if not self.card.media_height:
+                raise ValueError(
+                    'media_height must be specified when card_orientation is VERTICAL'
+                )
+        return self
 
 
 class RcsCarousel(BaseModel):

--- a/messages/src/vonage_messages/models/sms.py
+++ b/messages/src/vonage_messages/models/sms.py
@@ -52,7 +52,7 @@ class Sms(BaseMessage):
 
     from_: Union[PhoneNumber, str] = Field(..., serialization_alias='from')
     text: str = Field(..., max_length=1000)
-    ttl: Optional[int] = None
+    ttl: Optional[int] = Field(None, ge=20, le=604800)
     trusted_recipient: Optional[bool] = None
     sms: Optional[SmsOptions] = None
     channel: ChannelType = ChannelType.SMS

--- a/messages/tests/test_rcs_models.py
+++ b/messages/tests/test_rcs_models.py
@@ -748,7 +748,9 @@ def test_create_rcs_card_message_card_orientation_vertical_without_media_height(
                 card_orientation='VERTICAL',
             ),
         )
-    assert "media_height must be specified when card_orientation is VERTICAL" in str(err.value)
+    assert "media_height must be specified when card_orientation is VERTICAL" in str(
+        err.value
+    )
 
 
 def test_create_rcs_carousel():
@@ -1776,7 +1778,9 @@ def test_create_rcs_options_card_image_alignment_with_invalid_option():
 def test_create_rcs_options_card_card_orientation_horizontal_without_image_alignment():
     with pytest.raises(ValidationError) as err:
         options = RcsOptionsCard(card_orientation='HORIZONTAL')
-    assert "image_alignment must be specified when card_orientation is HORIZONTAL" in str(err.value)
+    assert "image_alignment must be specified when card_orientation is HORIZONTAL" in str(
+        err.value
+    )
 
 
 def test_create_rcs_options_carousel():

--- a/messages/tests/test_rcs_models.py
+++ b/messages/tests/test_rcs_models.py
@@ -703,7 +703,7 @@ def test_create_rcs_card_message_with_optional_params():
             media_url='https://example.com/image.jpg',
         ),
         rcs=RcsOptionsCard(
-            card_orientation='VERTICAL',
+            card_orientation='HORIZONTAL',
             image_alignment='LEFT',
         ),
     )
@@ -716,7 +716,7 @@ def test_create_rcs_card_message_with_optional_params():
             'media_url': 'https://example.com/image.jpg',
         },
         'rcs': {
-            'card_orientation': 'VERTICAL',
+            'card_orientation': 'HORIZONTAL',
             'image_alignment': 'LEFT',
         },
         'channel': 'rcs',
@@ -732,6 +732,23 @@ def test_create_rcs_card_message_without_card():
             from_='asdf1234',
         )
     assert "Field required" in str(err.value)
+
+
+def test_create_rcs_card_message_card_orientation_vertical_without_media_height():
+    with pytest.raises(ValidationError) as err:
+        card = RcsCardMessage(
+            to='1234567890',
+            from_='asdf1234',
+            card=RcsCard(
+                title='Card title',
+                text='Card description',
+                media_url='https://example.com/image.jpg',
+            ),
+            rcs=RcsOptionsCard(
+                card_orientation='VERTICAL',
+            ),
+        )
+    assert "media_height must be specified when card_orientation is VERTICAL" in str(err.value)
 
 
 def test_create_rcs_carousel():
@@ -1754,6 +1771,12 @@ def test_create_rcs_options_card_image_alignment_with_invalid_option():
             card_orientation='HORIZONTAL', image_alignment='INVALID_ALIGNMENT'
         )
     assert "Input should be 'LEFT' or 'RIGHT'" in str(err.value)
+
+
+def test_create_rcs_options_card_card_orientation_horizontal_without_image_alignment():
+    with pytest.raises(ValidationError) as err:
+        options = RcsOptionsCard(card_orientation='HORIZONTAL')
+    assert "image_alignment must be specified when card_orientation is HORIZONTAL" in str(err.value)
 
 
 def test_create_rcs_options_carousel():

--- a/messages/tests/test_sms_models.py
+++ b/messages/tests/test_sms_models.py
@@ -79,3 +79,25 @@ def test_create_sms_with_invalid_encoding_type():
             sms=SmsOptions(encoding_type='invalid'),
         )
     assert 'Input should be' in str(err.value)
+
+
+def test_create_sms_ttl_too_short():
+    with pytest.raises(ValidationError) as err:
+        Sms(
+            to='1234567890',
+            from_='1234567890',
+            text='Hello, World!',
+            ttl=19,
+        )
+    assert 'Number should be greater than or equal to 20' in str(err.value)
+
+
+def test_create_sms_ttl_too_long():
+    with pytest.raises(ValidationError) as err:
+        Sms(
+            to='1234567890',
+            from_='1234567890',
+            text='Hello, World!',
+            ttl=604801,
+        )
+    assert 'Number should be less than or equal to 604800' in str(err.value)

--- a/messages/tests/test_sms_models.py
+++ b/messages/tests/test_sms_models.py
@@ -89,7 +89,7 @@ def test_create_sms_ttl_too_short():
             text='Hello, World!',
             ttl=19,
         )
-    assert 'Number should be greater than or equal to 20' in str(err.value)
+    assert 'Input should be greater than or equal to 20' in str(err.value)
 
 
 def test_create_sms_ttl_too_long():
@@ -100,4 +100,4 @@ def test_create_sms_ttl_too_long():
             text='Hello, World!',
             ttl=604801,
         )
-    assert 'Number should be less than or equal to 604800' in str(err.value)
+    assert 'Input should be less than or equal to 604800' in str(err.value)


### PR DESCRIPTION
This PR updates some validations for the Messages API. Specifically it:

- Adds validations to the `ttl` param for `sms`
- Adds model validators for the conditional validations for `rcs` based on `card_orientation`