### PR TITLE
feat: Adding WhatsApp BSUID support to Messages

### DIFF
--- a/messages/src/vonage_messages/models/whatsapp.py
+++ b/messages/src/vonage_messages/models/whatsapp.py
@@ -26,8 +26,8 @@ class BaseWhatsapp(BaseMessage):
     """Model for a base WhatsApp message.
 
     Args:
-        to (Union[PhoneNumber, str]): The recipient's phone number in E.164 format. Don't use a
-            leading plus sign. Alternatively a BSUID.
+        to (str): The recipient's phone number in E.164 format. Don't use a
+            leading plus sign. Alternatively, a BSUID (e.g. "US.13491208655302741918").
         from_ (Union[PhoneNumber, str]): The sender's phone number in E.164 format.
             Don't use a leading plus sign.
         context (WhatsappContext, Optional): Used for quoting/replying/reacting to a

--- a/messages/src/vonage_messages/models/whatsapp.py
+++ b/messages/src/vonage_messages/models/whatsapp.py
@@ -26,8 +26,8 @@ class BaseWhatsapp(BaseMessage):
     """Model for a base WhatsApp message.
 
     Args:
-        to (PhoneNumber): The recipient's phone number in E.164 format. Don't use a
-            leading plus sign.
+        to (Union[PhoneNumber, str]): The recipient's phone number in E.164 format. Don't use a
+            leading plus sign. Alternatively a BSUID.
         from_ (Union[PhoneNumber, str]): The sender's phone number in E.164 format.
             Don't use a leading plus sign.
         context (WhatsappContext, Optional): Used for quoting/replying/reacting to a
@@ -43,6 +43,7 @@ class BaseWhatsapp(BaseMessage):
             will be used to send Status Webhook messages for this particular message.
     """
 
+    to: Union[PhoneNumber, str]
     from_: Union[PhoneNumber, str] = Field(..., serialization_alias='from')
     context: Optional[WhatsappContext] = None
     channel: ChannelType = ChannelType.WHATSAPP

--- a/messages/tests/test_whatsapp_models.py
+++ b/messages/tests/test_whatsapp_models.py
@@ -42,6 +42,23 @@ def test_whatsapp_text():
     assert whatsapp_model.model_dump(by_alias=True, exclude_none=True) == whatsapp_dict
 
 
+def test_whatsapp_text_with_bsuid():
+    whatsapp_model = WhatsappText(
+        to='US.13491208655302741918',
+        from_='1234567890',
+        text='Hello, World!',
+    )
+    whatsapp_dict = {
+        'to': 'US.13491208655302741918',
+        'from': '1234567890',
+        'text': 'Hello, World!',
+        'channel': 'whatsapp',
+        'message_type': 'text',
+    }
+
+    assert whatsapp_model.model_dump(by_alias=True, exclude_none=True) == whatsapp_dict
+
+
 def test_whatsapp_text_all_fields():
     whatsapp_model = WhatsappText(
         to='1234567890',


### PR DESCRIPTION
This PR updates the Messages package to add support for sending WhatsApp messages using a BSUID in the `to` field. Specifically it:

- Adds a unit test to cover setting a BSUID in the `to` field of a WhatsApp message object
- Updates the `BaseWhatsapp` model to allow the setting of the BSUID in the `to` field